### PR TITLE
Fiid 56/al iniciar la app el swich

### DIFF
--- a/lib/presentation/providers/settings_provider.dart
+++ b/lib/presentation/providers/settings_provider.dart
@@ -9,7 +9,7 @@ class SettingsProviderState {
 
   SettingsProviderState({
     required this.currentTheme,
-    required this.isDarkMode,
+    this.isDarkMode = false,
     required this.showWelcomeModal,
   });
 
@@ -30,12 +30,14 @@ class SettingsNotifierProvider extends StateNotifier<SettingsProviderState> {
   SettingsNotifierProvider({
     required bool isDarkMode,
     required bool showWelcomeModal,
-  }) : super(SettingsProviderState(
-          currentTheme:
-              isDarkMode ? AppTheme().darkTheme : AppTheme().lightTheme,
-          isDarkMode: isDarkMode,
-          showWelcomeModal: showWelcomeModal,
-        ));
+  }) : super(
+          SettingsProviderState(
+            currentTheme:
+                isDarkMode ? AppTheme().darkTheme : AppTheme().lightTheme,
+            isDarkMode: isDarkMode,
+            showWelcomeModal: showWelcomeModal,
+          ),
+        );
 
   void setLightMode() {
     state = state.copyWith(

--- a/lib/presentation/screens/home/home.dart
+++ b/lib/presentation/screens/home/home.dart
@@ -30,7 +30,8 @@ class HomeScreen extends HookConsumerWidget {
 
     return PopScope(
       child: Scaffold(
-        backgroundColor: Color(currentTheme.isDarkMode ? backgroundColorDark : whiteText),
+        backgroundColor:
+            Color(currentTheme.isDarkMode ? backgroundColorDark : whiteText),
         bottomNavigationBar: const BottomNavigationBarHome(),
         body: HookBuilder(
           builder: (context) {
@@ -38,7 +39,10 @@ class HomeScreen extends HookConsumerWidget {
 
             return userProfile.when(
               data: (profile) {
-                return HomeBody(currentTheme: currentTheme, userProfile: profile);
+                return HomeBody(
+                  currentTheme: currentTheme,
+                  userProfile: profile,
+                );
               },
               loading: () => const Center(child: CircularProgressIndicator()),
               error: (error, _) => Center(child: Text(error.toString())),
@@ -67,7 +71,8 @@ class HomeBody extends HookConsumerWidget {
         final hasCompletedOnboarding = ref.read(hasCompletedOnboardingProvider);
         if (hasCompletedOnboarding == false) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
-            Navigator.of(context).pushReplacementNamed('/onboarding_questions_start');
+            Navigator.of(context)
+                .pushReplacementNamed('/onboarding_questions_start');
           });
         }
         return null;
@@ -76,6 +81,12 @@ class HomeBody extends HookConsumerWidget {
     );
 
     final isSoles = ref.watch(isSolesStateProvider);
+    final themeProvider = ref.watch(settingsNotifierProvider);
+    final userBalanceReport = ref.watch(userProfileBalanceNotifierProvider);
+    final currency = ref.watch(isSolesStateProvider);
+    final userProfile = ref.watch(userProfileNotifierProvider);
+    final settings = ref.read(settingsNotifierProvider.notifier);
+
     return Padding(
       padding: const EdgeInsets.only(left: 15, right: 15, top: 60),
       child: SingleChildScrollView(
@@ -86,12 +97,21 @@ class HomeBody extends HookConsumerWidget {
               children: [
                 InkWell(
                   onTap: () {
-                    settingsDialog(context, ref);
+                    settingsDialog(
+                      context,
+                      ref,
+                      themeProvider,
+                      userBalanceReport,
+                      currency,
+                      userProfile,
+                      settings,
+                    );
                   },
                   child: Container(
                     alignment: Alignment.center,
                     child: CircularPercentAvatarWidget(
-                        ref.watch(userProfileNotifierProvider).percentCompleteProfile ?? 0.0),
+                      userProfile.percentCompleteProfile ?? 0.0,
+                    ),
                   ),
                 ),
                 const SizedBox(
@@ -105,7 +125,9 @@ class HomeBody extends HookConsumerWidget {
                     style: TextStyle(
                       fontSize: 24,
                       fontWeight: FontWeight.w600,
-                      color: currentTheme.isDarkMode ? const Color(whiteText) : const Color(primaryDark),
+                      color: currentTheme.isDarkMode
+                          ? const Color(whiteText)
+                          : const Color(primaryDark),
                     ),
                   ),
                 ),
@@ -115,7 +137,9 @@ class HomeBody extends HookConsumerWidget {
                     'assets/images/logo_small.png',
                     width: 60,
                     height: 60,
-                    color: currentTheme.isDarkMode ? const Color(whiteText) : const Color(blackText),
+                    color: currentTheme.isDarkMode
+                        ? const Color(whiteText)
+                        : const Color(blackText),
                   ),
                 ),
               ],
@@ -130,8 +154,10 @@ class HomeBody extends HookConsumerWidget {
                   data: (data) {
                     var reportSoles = data.solesBalance;
                     var reportDolar = data.dolarBalance;
-                    var homeReport = isSoles ? data.solesBalance : data.dolarBalance;
-                    if (reportSoles.totalBalance == 0 && reportDolar.totalBalance == 0) {
+                    var homeReport =
+                        isSoles ? data.solesBalance : data.dolarBalance;
+                    if (reportSoles.totalBalance == 0 &&
+                        reportDolar.totalBalance == 0) {
                       return SizedBox(
                         height: MediaQuery.of(context).size.height * 0.4,
                         child: const Center(
@@ -169,7 +195,9 @@ class HomeBody extends HookConsumerWidget {
             Container(
               height: 2,
               width: MediaQuery.of(context).size.width * 0.8,
-              color: currentTheme.isDarkMode ? const Color(primaryLight) : const Color(primaryDark),
+              color: currentTheme.isDarkMode
+                  ? const Color(primaryLight)
+                  : const Color(primaryDark),
             ),
             const SizedBox(
               height: 15,
@@ -199,10 +227,12 @@ class PendingInvestmentCardWidget extends StatefulHookConsumerWidget {
   final SettingsProviderState currentTheme;
 
   @override
-  ConsumerState<PendingInvestmentCardWidget> createState() => PendingInvestmentCardWidgetState();
+  ConsumerState<PendingInvestmentCardWidget> createState() =>
+      PendingInvestmentCardWidgetState();
 }
 
-class PendingInvestmentCardWidgetState extends ConsumerState<PendingInvestmentCardWidget> {
+class PendingInvestmentCardWidgetState
+    extends ConsumerState<PendingInvestmentCardWidget> {
   // bool hasInvestmentInProcess = false;
   bool isLoading = false;
   PreInvestmentForm? preInvestmentForm;
@@ -218,7 +248,9 @@ class PendingInvestmentCardWidgetState extends ConsumerState<PendingInvestmentCa
         setState(() {
           isLoading = true;
         });
-        InvestmentRepository().userHasInvestmentInProcess(client: gqlClient!).then(
+        InvestmentRepository()
+            .userHasInvestmentInProcess(client: gqlClient!)
+            .then(
           (success) {
             if (mounted) {
               setState(() {

--- a/lib/presentation/screens/home/widgets/modals.dart
+++ b/lib/presentation/screens/home/widgets/modals.dart
@@ -1,32 +1,26 @@
 import 'package:finniu/constants/colors.dart';
 import 'package:finniu/constants/number_format.dart';
-import 'package:finniu/presentation/providers/auth_provider.dart';
-import 'package:finniu/presentation/providers/bank_provider.dart';
-import 'package:finniu/presentation/providers/bank_repository_provider.dart';
-import 'package:finniu/presentation/providers/dead_line_provider.dart';
-import 'package:finniu/presentation/providers/graphql_provider.dart';
-import 'package:finniu/presentation/providers/important_days_provider.dart';
-import 'package:finniu/presentation/providers/money_provider.dart';
-import 'package:finniu/presentation/providers/onboarding_provider.dart';
-import 'package:finniu/presentation/providers/otp_provider.dart';
-import 'package:finniu/presentation/providers/plan_provider.dart';
-import 'package:finniu/presentation/providers/pre_investment_provider.dart';
-import 'package:finniu/presentation/providers/report_provider.dart';
+import 'package:finniu/domain/entities/userProfileBalance.dart';
+import 'package:finniu/infrastructure/models/user.dart';
 import 'package:finniu/presentation/providers/settings_provider.dart';
 import 'package:finniu/presentation/providers/user_provider.dart';
 import 'package:finniu/services/share_preferences_service.dart';
+import 'package:finniu/utils/log_out.dart';
 import 'package:finniu/widgets/avatar.dart';
 import 'package:finniu/widgets/fonts.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_switch/flutter_switch.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-void settingsDialog(BuildContext ctx, WidgetRef ref) {
-  final themeProvider = ref.watch(settingsNotifierProvider);
-  final userBalanceReport = ref.watch(userProfileBalanceNotifierProvider);
-  final currency = ref.watch(isSolesStateProvider);
-  final userProfile = ref.watch(userProfileNotifierProvider);
-
+void settingsDialog(
+  BuildContext ctx,
+  WidgetRef ref,
+  SettingsProviderState themeProvider,
+  UserProfileBalance userBalanceReport,
+  bool currency,
+  UserProfile userProfile,
+  SettingsNotifierProvider settings,
+) {
   // final themeProvider = Provider.of<SettingsProvider>(ctx, listen: false);
   showDialog(
     context: ctx,
@@ -113,12 +107,7 @@ void settingsDialog(BuildContext ctx, WidgetRef ref) {
                                   SizedBox(
                                     width: 120,
                                     child: Text(
-                                      ref
-                                              .watch(
-                                                userProfileNotifierProvider,
-                                              )
-                                              .nickName ??
-                                          '',
+                                      userProfile.nickName ?? '',
                                       style: TextStyle(
                                         height: 1.5,
                                         fontSize: 16,
@@ -132,7 +121,9 @@ void settingsDialog(BuildContext ctx, WidgetRef ref) {
                                   ),
                                   const Spacer(),
                                   TextPoppins(
-                                    text: 'Light mode',
+                                    text: themeProvider.isDarkMode
+                                        ? 'Dark mode'
+                                        : 'Light mode',
                                     colorText: themeProvider.isDarkMode
                                         ? Colors.white.value
                                         : Colors.black.value,
@@ -145,7 +136,8 @@ void settingsDialog(BuildContext ctx, WidgetRef ref) {
                                     padding: 2,
                                     width: 35,
                                     height: 16,
-                                    value: Preferences.isDarkMode,
+                                    value:
+                                        themeProvider.isDarkMode ? true : false,
                                     inactiveColor: const Color(primaryDark),
                                     activeColor: const Color(primaryLight),
                                     inactiveToggleColor:
@@ -153,18 +145,8 @@ void settingsDialog(BuildContext ctx, WidgetRef ref) {
                                     activeToggleColor: const Color(primaryDark),
                                     onToggle: (value) {
                                       value
-                                          ? ref
-                                              .read(
-                                                settingsNotifierProvider
-                                                    .notifier,
-                                              )
-                                              .setDarkMode()
-                                          : ref
-                                              .read(
-                                                settingsNotifierProvider
-                                                    .notifier,
-                                              )
-                                              .setLightMode();
+                                          ? settings.setDarkMode()
+                                          : settings.setLightMode();
                                       Preferences.isDarkMode = value;
                                       Navigator.of(context).pop();
                                     },
@@ -177,10 +159,7 @@ void settingsDialog(BuildContext ctx, WidgetRef ref) {
                                     width: 10,
                                   ),
                                   Text(
-                                    ref
-                                            .watch(userProfileNotifierProvider)
-                                            .email ??
-                                        '',
+                                    userProfile.email ?? '',
                                     style: TextStyle(
                                       height: 1.5,
                                       fontSize: 12,
@@ -346,48 +325,11 @@ void settingsDialog(BuildContext ctx, WidgetRef ref) {
                             child: ItemSetting(
                               image: 'assets/icons/sign_off.png',
                               text: "Cerrar sesión",
-                              onTap: () {
-                                ref.invalidate(authTokenProvider);
-                                ref.invalidate(gqlClientProvider);
-                                ref.invalidate(userProfileFutureProvider);
-                                ref.invalidate(bankFutureProvider);
-                                ref.invalidate(deadLineFutureProvider);
-                                ref.invalidate(hasCompletedOnboardingProvider);
-                                ref.invalidate(userAcceptedTermsProvider);
-                                ref.invalidate(
-                                  finishOnboardingFutureStateNotifierProvider,
-                                );
-                                ref.invalidate(importantDaysFutureProvider);
-                                ref.invalidate(
-                                  startOnBoardingFutureStateNotifierProvider,
-                                );
-                                ref.invalidate(
-                                  updateOnboardingFutureStateNotifierProvider,
-                                );
-                                ref.invalidate(onBoardingStateNotifierProvider);
-                                ref.invalidate(
-                                  recommendedPlanStateNotifierProvider,
-                                );
-                                ref.invalidate(otpValidatorFutureProvider);
-                                ref.invalidate(otpResendCodeProvider);
-                                ref.invalidate(planListFutureProvider);
-                                ref.invalidate(preInvestmentSaveProvider);
-                                ref.invalidate(homeReportProvider);
-                                ref.invalidate(userProfileNotifierProvider);
-                                ref.invalidate(
-                                  userProfileBalanceNotifierProvider,
-                                );
-                                ref.invalidate(settingsNotifierProvider);
-                                ref.invalidate(isSolesStateProvider);
-                                ref.invalidate(homeReportProviderV2);
-                                ref.invalidate(bankRepositoryProvider);
-                                // logout(ref);
-                                Navigator.of(ctx).pushNamedAndRemoveUntil(
-                                  '/login_start',
-                                  (route) => true,
-                                );
-                                // Navigator.of(ctx).pushNamed('/login_start');
-                              },
+                              onTap: () => logOut(
+                                ctx,
+                                ref,
+                              ) // Navigator.of(ctx).pushNamed('/login_start');
+                              ,
                             ),
                           ),
                         ],

--- a/lib/utils/log_out.dart
+++ b/lib/utils/log_out.dart
@@ -1,0 +1,58 @@
+import 'package:finniu/presentation/providers/auth_provider.dart';
+import 'package:finniu/presentation/providers/bank_provider.dart';
+import 'package:finniu/presentation/providers/bank_repository_provider.dart';
+import 'package:finniu/presentation/providers/dead_line_provider.dart';
+import 'package:finniu/presentation/providers/graphql_provider.dart';
+import 'package:finniu/presentation/providers/important_days_provider.dart';
+import 'package:finniu/presentation/providers/money_provider.dart';
+import 'package:finniu/presentation/providers/onboarding_provider.dart';
+import 'package:finniu/presentation/providers/otp_provider.dart';
+import 'package:finniu/presentation/providers/plan_provider.dart';
+import 'package:finniu/presentation/providers/pre_investment_provider.dart';
+import 'package:finniu/presentation/providers/report_provider.dart';
+import 'package:finniu/presentation/providers/settings_provider.dart';
+import 'package:finniu/presentation/providers/user_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+logOut(BuildContext context, WidgetRef ref) {
+  ref.invalidate(authTokenProvider);
+  ref.invalidate(gqlClientProvider);
+  ref.invalidate(userProfileFutureProvider);
+  ref.invalidate(bankFutureProvider);
+  ref.invalidate(deadLineFutureProvider);
+  ref.invalidate(hasCompletedOnboardingProvider);
+  ref.invalidate(userAcceptedTermsProvider);
+  ref.invalidate(
+    finishOnboardingFutureStateNotifierProvider,
+  );
+  ref.invalidate(importantDaysFutureProvider);
+  ref.invalidate(
+    startOnBoardingFutureStateNotifierProvider,
+  );
+  ref.invalidate(
+    updateOnboardingFutureStateNotifierProvider,
+  );
+  ref.invalidate(onBoardingStateNotifierProvider);
+  ref.invalidate(
+    recommendedPlanStateNotifierProvider,
+  );
+  ref.invalidate(otpValidatorFutureProvider);
+  ref.invalidate(otpResendCodeProvider);
+  ref.invalidate(planListFutureProvider);
+  ref.invalidate(preInvestmentSaveProvider);
+  ref.invalidate(homeReportProvider);
+  ref.invalidate(userProfileNotifierProvider);
+  ref.invalidate(
+    userProfileBalanceNotifierProvider,
+  );
+  ref.invalidate(settingsNotifierProvider);
+  ref.invalidate(isSolesStateProvider);
+  ref.invalidate(homeReportProviderV2);
+  ref.invalidate(bankRepositoryProvider);
+  // logout(ref);
+  Navigator.of(context).pushNamedAndRemoveUntil(
+    '/login_start',
+    (route) => true,
+  );
+}

--- a/lib/widgets/scaffold.dart
+++ b/lib/widgets/scaffold.dart
@@ -2,7 +2,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_switch/flutter_switch.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-
 import 'package:finniu/constants/colors.dart';
 import 'package:finniu/presentation/providers/settings_provider.dart';
 import 'package:finniu/services/share_preferences_service.dart';
@@ -22,6 +21,7 @@ class _CustomScaffoldStartState extends ConsumerState<CustomScaffoldStart> {
   @override
   Widget build(BuildContext context) {
     final themeProvider = ref.watch(settingsNotifierProvider);
+    final settings = ref.read(settingsNotifierProvider.notifier);
     // final themeProvider = Provider.of<SettingsProvider>(context, listen: false);
 
     return Scaffold(
@@ -37,29 +37,24 @@ class _CustomScaffoldStartState extends ConsumerState<CustomScaffoldStart> {
             mainAxisAlignment: MainAxisAlignment.end,
             children: <Widget>[
               TextPoppins(
-                  text: themeProvider.isDarkMode ? 'Dark mode' : 'Light mode',
-                  colorText: Theme.of(context).colorScheme.primary.value,
-                  // colorText: ,
-                  fontSize: 10,
-                  fontWeight: FontWeight.w500),
+                text: themeProvider.isDarkMode ? 'Dark mode' : 'Light mode',
+                colorText: Theme.of(context).colorScheme.primary.value,
+                // colorText: ,
+                fontSize: 10,
+                fontWeight: FontWeight.w500,
+              ),
               const SizedBox(width: 5),
               FlutterSwitch(
                 width: 45,
                 height: 24,
-                value: Preferences.isDarkMode,
+                value: themeProvider.isDarkMode ? true : false,
                 inactiveColor: const Color(primaryDark),
                 activeColor: const Color(primaryLight),
                 inactiveToggleColor: const Color(primaryLight),
                 activeToggleColor: const Color(primaryDark),
                 onToggle: (value) {
                   Preferences.isDarkMode = value;
-                  value
-                      ? ref
-                          .read(settingsNotifierProvider.notifier)
-                          .setDarkMode()
-                      : ref
-                          .read(settingsNotifierProvider.notifier)
-                          .setLightMode();
+                  value ? settings.setDarkMode() : settings.setLightMode();
                   setState(() {});
                 },
               ),
@@ -188,6 +183,7 @@ class CustomScaffoldReturnDirect extends ConsumerWidget {
   bool hideReturnButton;
 
   CustomScaffoldReturnDirect({
+    super.key,
     required this.body,
     this.hideReturnButton = false,
   });

--- a/lib/widgets/snackbar.dart
+++ b/lib/widgets/snackbar.dart
@@ -110,14 +110,16 @@ class SnackBarBody extends HookConsumerWidget {
               ),
             ),
             Positioned(
-              right: 5,
-              top: 2,
+              right: 7,
+              top: 6,
               child: InkWell(
                 onTap: onDismiss,
-                child: const SizedBox(
-                  width: 40,
-                  height: 40,
-                ),
+                child: themeProvider.isDarkMode
+                    ? const Icon(Icons.close, color: Colors.white)
+                    : const SizedBox(
+                        width: 40,
+                        height: 40,
+                      ),
               ),
             ),
           ],


### PR DESCRIPTION
- "al iniciar la app el swich"[FIID-56](https://finniu-tech.atlassian.net/browse/FIID-56)
-  CustomScaffoldStart adds “final settings” that reads settingsNotifierProvider.notifier (sometimes it gave an error on line 56).
- In utils, the log_out function is added that performs the section closing and navigation invalidates. 
- In home/widgets/modals.dart the watch is removed from the providers and those values ​​are received by parameter.
- In ItemSetting, the logOut function is executed and the invalidates are passed to log_out.  
- in home you listen to the providers to pass the parameters to settingsDialog
- example [video](https://finniu-tech.atlassian.net/jira/software/c/projects/FIID/boards/1?assignee=712020%3A1b4174d0-c8b0-46c8-aa5c-4d12c95af17b&selectedIssue=FIID-56)
- "el boton de cerrar el snackbar " [FIID-55](https://finniu-tech.atlassian.net/browse/FIID-55)
- push error when not creating branch for task
- snackBar in darkMode case a white close icon is added (previously it was shown in blue and was not visible)


![snackbar_dark](https://github.com/Finniu-Tech/finniu_mobile/assets/172281422/c3d32a84-986b-46f4-a098-3c10df1be18d)
![snackbar_light](https://github.com/Finniu-Tech/finniu_mobile/assets/172281422/e5765f7d-cf54-4f7e-a914-740cf7ff7d60)
